### PR TITLE
Update for new API key length, null payer_id

### DIFF
--- a/R/ynab_functions.R
+++ b/R/ynab_functions.R
@@ -525,7 +525,7 @@ ynab_get_account_data <- function(bd, exclude_subtransactions = TRUE) {
         approved = .x[["approved"]],
         flag_color = ifelse(is.null(.x[["flag_color"]]), NA, .x[["flag_color"]]),
         account_id = .x[["account_id"]],
-        payee_id = .x[["payee_id"]],
+        payee_id = ifelse(is.null(.x[["payee_id"]]), NA, .x[["payee_id"]]),
         category_id = ifelse(is.null(.x[["category_id"]]), NA, .x[["category_id"]]),
         transfer_account_id = ifelse(is.null(.x[["transfer_account_id"]]), NA,
           .x[["transfer_account_id"]]

--- a/R/ynab_functions.R
+++ b/R/ynab_functions.R
@@ -27,8 +27,8 @@ ynab_set_token <- function(token = NULL) {
   }
 
   # Check the length of the token argument
-  if (nchar(token) != 64) {
-    stop("The token argument must have a length of 64.")
+  if (nchar(token) == 0) {
+    stop("The token argument must be of non-zero length")
   }
 
   # Set the ynab_token option


### PR DESCRIPTION
This library wasn't working for me as-is, turns out just a couple simple fixes got me up and running:
 - Remove the 64-char API key check (my API key is less than 64 characters, they must have changed something)
 - Allow payee_id to be null (I had some empty payees, apparently)